### PR TITLE
fix header cell scroll left issue.

### DIFF
--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -8,7 +8,7 @@ export default Ember.View.extend(
 StyleBindingsMixin, RegisterTableComponentMixin, {
   templateName: 'header-row',
   classNames: ['ember-table-table-row', 'ember-table-header-row'],
-  styleBindings: ['top', 'height'],
+  styleBindings: ['width', 'top', 'height'],
   columns: Ember.computed.alias('content'),
   width: Ember.computed.alias('tableComponent._rowWidth'),
   scrollLeft: Ember.computed.alias('tableComponent._tableScrollLeft'),


### PR DESCRIPTION
Fix: non-grouping columns are not moving when scroll to left.