### PR TITLE
remove unused property in ember table.

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -28,7 +28,6 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   // TODO(new-api): Rename to `data`
   columns: null,
 
-  columnGroups: null,
   // The number of fixed columns on the left side of the table. Fixed columns
   // are always visible, even when the table is scrolled horizontally.
   numFixedColumns: 0,
@@ -128,9 +127,6 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   columnsFillTable: true,
 
   init: function() {
-    if (this.get('hasColumnGroup')) {
-      this.set('columnGroups', this.get('columns'));
-    }
 
     this._super();
     if (!Ember.$.ui) {

--- a/addon/views/header-groups-block.js
+++ b/addon/views/header-groups-block.js
@@ -39,7 +39,7 @@ export default Ember.CollectionView.extend(
     }).property('columnGroups.@each'),
 
     createChildView: function (view, attrs) {
-      var columnGroups = this.get('tableComponent.columnGroups');
+      var columnGroups = this.get('tableComponent.columns');
       var childView = view.extend({
         scrollLeft: this.get('scrollLeft'),
         height: this.get('height'),

--- a/app/templates/header-table-container.hbs
+++ b/app/templates/header-table-container.hbs
@@ -8,7 +8,7 @@
   {{/if}}
   {{#if hasColumnGroup}}
     {{view "header-groups-block" classNames="ember-table-header-groups-block"
-    columnGroups=columnGroups
+    columnGroups=columns
     scrollLeft=_tableScrollLeft
     }}
   {{else}}


### PR DESCRIPTION
  - columnGroup is not needed in ember-table