### PR TITLE
add grouping column and add internal columns 

### DIFF
--- a/addon/views/header-groups-block.js
+++ b/addon/views/header-groups-block.js
@@ -39,7 +39,7 @@ export default Ember.CollectionView.extend(
     }).property('columnGroups.@each'),
 
     createChildView: function (view, attrs) {
-      var columnGroups = this.get('tableComponent.columns');
+      var columnGroups = this.get('tableComponent._columns');
       var childView = view.extend({
         scrollLeft: this.get('scrollLeft'),
         height: this.get('height'),

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -10,7 +10,12 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
   classNames: ['ember-table-table-row', 'ember-table-header-row'],
   styleBindings: ['width', 'top', 'height'],
   columns: Ember.computed.alias('content'),
-  width: Ember.computed.alias('tableComponent._rowWidth'),
+  width: Ember.computed(function() {
+    var widths = this.get('columns').getEach('width');
+    return widths.reduce(function (width, res) {
+      return width + res;
+    }, 0);
+  }).property('columns.@each.width'),
   scrollLeft: Ember.computed.alias('tableComponent._tableScrollLeft'),
 
   rowWidth: Ember.computed(function() {

--- a/addon/views/header-table-container.js
+++ b/addon/views/header-table-container.js
@@ -19,7 +19,6 @@ ShowHorizontalScrollMixin, RegisterTableComponentMixin, {
   }).property('tableComponent._headerHeight'),
 
   width: Ember.computed.alias('tableComponent._tableContainerWidth'),
-  hasColumnGroup: Ember.computed(function() {
-    return this.get('tableComponent.hasColumnGroup');
-  })
+
+  hasColumnGroup: Ember.computed.oneWay('tableComponent.hasColumnGroup')
 });

--- a/addon/views/table-row.js
+++ b/addon/views/table-row.js
@@ -14,7 +14,12 @@ RegisterTableComponentMixin, {
   styleBindings: ['width', 'height'],
   row: Ember.computed.alias('content'),
   columns: Ember.computed.alias('parentView.columns'),
-  width: Ember.computed.alias('tableComponent._rowWidth'),
+  width: Ember.computed(function() {
+    var widths = this.get('columns').getEach('width');
+    return widths.reduce(function (width, res) {
+      return width + res;
+    }, 0);
+  }).property('columns.@each.width'),
   height: Ember.computed.alias('tableComponent.rowHeight'),
 
   isLastRow: Ember.computed(function() {

--- a/app/templates/body-table-container.hbs
+++ b/app/templates/body-table-container.hbs
@@ -1,7 +1,7 @@
 <div class="antiscroll-box">
   <div class="antiscroll-inner">
     <div class="ember-table-table-scrollable-wrapper">
-      {{#if numFixedColumns}}
+      {{#if _numFixedColumns }}
         {{view "lazy-table-block" classNames="ember-table-left-table-block"
           content=bodyContent
           columns=fixedColumns

--- a/app/templates/header-table-container.hbs
+++ b/app/templates/header-table-container.hbs
@@ -1,5 +1,5 @@
 <div class="ember-table-table-fixed-wrapper">
-  {{#if controller.numFixedColumns}}
+  {{#if _numFixedColumns}}
     {{view "header-block" classNames="ember-table-left-table-block"
       columns=fixedColumns
       width=_fixedBlockWidth

--- a/app/templates/header-table-container.hbs
+++ b/app/templates/header-table-container.hbs
@@ -8,7 +8,7 @@
   {{/if}}
   {{#if hasColumnGroup}}
     {{view "header-groups-block" classNames="ember-table-header-groups-block"
-    columnGroups=columns
+    columnGroups=_columns
     scrollLeft=_tableScrollLeft
     }}
   {{else}}

--- a/app/templates/table-row.hbs
+++ b/app/templates/table-row.hbs
@@ -2,5 +2,4 @@
   rowBinding="view.row"
   contentBinding="view.columns"
   itemViewClassField="tableCellViewClass"
-  widthBinding="controller._tableColumnsWidth"
 }}

--- a/tests/unit/components/ember-table-test.js
+++ b/tests/unit/components/ember-table-test.js
@@ -94,7 +94,7 @@ test('Should resize group width when inner column size changed', function (asser
   assert.ok(getGroupColumnWidth(this) === 300, 'Should be width before change');
 
   Ember.run(function () {
-    var thirdColumn = component.columns[1].innerColumns[1];
+    var thirdColumn = component.get('columns')[1].innerColumns[1];
     thirdColumn.resize(500);
   });
   assert.ok(getGroupColumnWidth(this) === 650, 'Should be width after change');
@@ -110,7 +110,7 @@ function getInnerColumn(table, columnIndex) {
 
 test('Should reorder inner columns when dragging the inner column', function (assert) {
   var component = tableFixture.groupTable(this);
-  var firstCol = component.columns[1].innerColumns[0];
+  var firstCol = component.get('columns')[1].innerColumns[0];
 
   Ember.run(function () {
     component.onColumnSort(firstCol, 1);

--- a/tests/unit/components/ember-table-test.js
+++ b/tests/unit/components/ember-table-test.js
@@ -94,7 +94,7 @@ test('Should resize group width when inner column size changed', function (asser
   assert.ok(getGroupColumnWidth(this) === 300, 'Should be width before change');
 
   Ember.run(function () {
-    var thirdColumn = component.get('columns')[1].innerColumns[1];
+    var thirdColumn = component.get('_columns')[1].innerColumns[1];
     thirdColumn.resize(500);
   });
   assert.ok(getGroupColumnWidth(this) === 650, 'Should be width after change');
@@ -110,7 +110,7 @@ function getInnerColumn(table, columnIndex) {
 
 test('Should reorder inner columns when dragging the inner column', function (assert) {
   var component = tableFixture.groupTable(this);
-  var firstCol = component.get('columns')[1].innerColumns[0];
+  var firstCol = component.get('_columns')[1].innerColumns[0];
 
   Ember.run(function () {
     component.onColumnSort(firstCol, 1);

--- a/tests/unit/components/grouping-column-test.js
+++ b/tests/unit/components/grouping-column-test.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import {
+  moduleForComponent,
+  test
+  }
+  from 'ember-qunit';
+
+import LazyArray from 'ember-table/models/lazy-array';
+import TableFixture from '../../fixture/table';
+
+var tableFixture = TableFixture.create();
+moduleForComponent('ember-table', 'EmberTableComponent', {
+  needs: tableFixture.get('needs')
+});
+
+test('it should has a grouping column at most left position', function (assert) {
+  var component = tableFixture.table(this);
+
+  Ember.run(function () {
+    component.set('hasGroupingColumn',true);
+  });
+
+  var fixedColumns = this.$('.ember-table-left-table-block > .ember-table-table-row > .ui-sortable > .ember-table-header-cell');
+  assert.equal(fixedColumns.length, 1);
+});
+

--- a/tests/unit/components/partial-data-sort-test.js
+++ b/tests/unit/components/partial-data-sort-test.js
@@ -20,7 +20,7 @@ test('should call set sort function with clicked column when sort partial data',
   component.set('setSortConditionBy', 'setSort');
   component.set('targetObject', Ember.Object.create({
     setSort: function (column) {
-      assert.equal(column, component.columns[0]);
+      assert.equal(column, component.get('columns')[0]);
     }
   }));
 


### PR DESCRIPTION
1. Added a grouping column.

2. Replace `columns` by `_columns` in ember table. So we can add our options to `_columns` and don't change user's `columns` .