### PR TITLE
Grouping column lable

### DIFF
--- a/addon/controllers/grouped-row-array.js
+++ b/addon/controllers/grouped-row-array.js
@@ -182,13 +182,17 @@ export default RowArrayController.extend({
       var child = children.objectAt(i);
       var decision = visitChild(child, content, level || 0);
       if (decision.stop) {
-        break;
+        return decision;
       }
       var needGoDeeper = decision.needGoDeeper;
       if (needGoDeeper) {
-        _this.depthFirstTraverse(child, visitChild, (level || 0) + 1);
+        var nextLevelDecision = _this.depthFirstTraverse(child, visitChild, (level || 0) + 1);
+        if (nextLevelDecision && nextLevelDecision.stop) {
+          return nextLevelDecision;
+        }
       }
     }
+    return {stop: false};
   },
 
   arrayLength: function(array) {

--- a/addon/models/grouping-row-proxy.js
+++ b/addon/models/grouping-row-proxy.js
@@ -28,5 +28,13 @@ export default Ember.ObjectProxy.extend({
       parentQuery: this.get('selfQuery')
     });
     return lazyArray;
-  }).property()
+  }).property(),
+
+  groupName: Ember.computed(function() {
+    var groupingName = this.get('groupingName');
+    if (groupingName) {
+      return this.get(groupingName);
+    }
+    return "";
+  }).property('groupingName', 'content')
 });

--- a/tests/unit/components/chunked-grouping-row-test.js
+++ b/tests/unit/components/chunked-grouping-row-test.js
@@ -6,17 +6,16 @@ import EmberTableHelper from '../../helpers/ember-table-helper';
 import LazyGroupRowArray from 'ember-table/models/lazy-group-row-array';
 import DeferPromises from '../../fixture/defer-promises';
 
-
 moduleForEmberTable('Given a table with chunked group row data',
-  function (testEnv) {
+  function (defers) {
     var chunkSize = 5;
     return EmberTableFixture.create({
-      height: 500,
+      height: 600,
       width: 700,
       content: LazyGroupRowArray.create(
         {
           loadChildren: function getChunk(chunkIndex, parentQuery) {
-            var defer = testEnv.get('defers')[chunkIndex];
+            var defer = defers.next();
             var result = {
               content: [],
               meta: {totalCount: 10, chunkSize: chunkSize}
@@ -24,85 +23,85 @@ moduleForEmberTable('Given a table with chunked group row data',
             for (var i = 0; i < chunkSize; i++) {
               var childrenStart = 10 * (chunkIndex + 1);
               result.content.push({
-                id: i, name: 'name-' + i,
-                children: [
-                  {id: childrenStart + 1, name: 'child-name-' + childrenStart + 1},
-                  {id: childrenStart + 2, name: 'child-name-' + childrenStart + 2}
-                ]
+                id: i, name: 'name-' + i
               });
             }
             defer.resolve(result);
             return defer.promise;
-          }
+          },
+          groupingMetadata: ["", ""]
         }),
       groupingMetadata: ["", ""]
     });
   });
 
 test('top level grouping rows are in chunk', function (assert) {
-  var testEnv = DeferPromises.create({defersCount: 2});
-  var component = this.subject(testEnv);
+  var defers = DeferPromises.create({count: 2});
+  var component = this.subject(defers);
   this.render();
   var helper = EmberTableHelper.create({_assert: assert, _component: component});
-  return testEnv.ready(function(){
+  return defers.ready(function () {
     assert.equal(helper.fixedBodyRows().length, 12, 'should render two chunks of rows');
     assert.equal(helper.rowGroupingIndicator(0).length, 1, 'first row is grouping row');
   });
 });
 
 test('expand chunked top level rows', function (assert) {
-  var testEnv = DeferPromises.create({defersCount: 2});
-  var component = this.subject(testEnv);
+  var defers = DeferPromises.create({count: 4});
+  var component = this.subject(defers);
   this.render();
   var helper = EmberTableHelper.create({_assert: assert, _component: component});
-  return testEnv.ready(function(){
+
+  defers.ready(function () {
     helper.rowGroupingIndicator(0).click();
+  }, [0, 1]);
+
+  return defers.ready(function () {
     assert.equal(helper.rowGroupingIndicator(0).hasClass("unfold"), true, 'grouping row is expanded');
-    assert.equal(helper.fixedBodyRows().length, 14, 'children rows are displayed');
+    assert.equal(helper.fixedBodyRows().length, 21, 'children rows are displayed');
   });
 });
 
 test('collapse chunked top level rows', function (assert) {
-  var testEnv = DeferPromises.create({defersCount: 2});
-  var component = this.subject(testEnv);
+  var defers = DeferPromises.create({count: 4});
+  var component = this.subject(defers);
   this.render();
   var helper = EmberTableHelper.create({_assert: assert, _component: component});
-  return testEnv.ready(function(){
-      helper.rowGroupingIndicator(0).click();
-      helper.rowGroupingIndicator(0).click();
 
-      assert.equal(helper.rowGroupingIndicator(0).hasClass("unfold"), false, 'grouping row is collapsed');
-      assert.equal(helper.fixedBodyRows().length, 12, 'children rows are collapsed');
+  defers.ready(function () {
+    helper.rowGroupingIndicator(0).click();
+    helper.rowGroupingIndicator(0).click();
+  }, [0, 1]);
+
+  return defers.ready(function () {
+    assert.equal(helper.rowGroupingIndicator(0).hasClass("unfold"), false, 'grouping row is collapsed');
+    assert.equal(helper.fixedBodyRows().length, 12, 'children rows are collapsed');
   });
 });
 
-moduleForEmberTable('Given a table with 3 chunked group row data',  function subject(content) {
-    return EmberTableFixture.create({
-      height: 90,
-      width: 700,
-      content: content,
-      groupingMetadata: ["", ""]
-    });
+moduleForEmberTable('Given a table with 3 chunked group row data', function subject(content) {
+  return EmberTableFixture.create({
+    height: 90,
+    width: 700,
+    content: content,
+    groupingMetadata: ["", ""]
+  });
 });
 
-test('load top level chunk data in need', function(assert) {
-  var testEnv = DeferPromises.create({defersCount: 1});
+test('load top level chunk data in need', function (assert) {
+  var defers = DeferPromises.create({count: 1});
   var chunkSize = 5;
   var loadedChunkCount = 0;
   var component = this.subject(LazyGroupRowArray.create(
     {
       loadChildren: function getChunk(pageIndex, parentQuery) {
-        var defer = testEnv.get('defers')[pageIndex];
+        var defer = defers.next();
         loadedChunkCount++;
         var result = [];
         for (var i = 0; i < chunkSize; i++) {
           var childrenStart = 10 * (pageIndex + 1);
           result.push({
-            id: i, name: 'name-' + i,
-            children: [
-              {id: childrenStart + 1, name: 'child-name-' + childrenStart + 1},
-              {id: childrenStart + 2, name: 'child-name-' + childrenStart + 2}
-            ]
+            id: i, name: 'name-' + i
           });
         }
         defer.resolve({content: result, meta: {totalCount: 15, chunkSize: 5}});
@@ -114,7 +113,7 @@ test('load top level chunk data in need', function(assert) {
 
   this.render();
 
-  return testEnv.ready(function () {
+  return defers.ready(function () {
     assert.equal(loadedChunkCount, 1, 'should only load first chunk');
   });
- });
+});


### PR DESCRIPTION
1. Refactored `DefersPromise` helper to `ArrayProxy`.
2. Fixed component tests for lazily loading grouped rows.
2. Not load second chunk of first level when expand.
4. Displayed group label in grouping column. 