### PR TITLE
use action for notifying load data error.

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -238,12 +238,18 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   //Do not want to create a new groupedRowController, even if its content length did change as more chunks are loaded.
   //If a new groupedRowController is created, the expanding state will be cleared.
   _groupedRowController: Ember.computed(function(){
+    var table = this;
+    var content = this.get('content');
+    content.set('onLoadError', function(errorMessage, groupingName, chunkIndex) {
+      table.sendAction('handleDataLoadingError', errorMessage, groupingName, chunkIndex);
+    });
+
     return GroupedRowArrayController.create({
       target: this,
       parentController: this,
       container: this.get('container'),
       itemController: Row,
-      content: this.get('content')
+      content: content
     });
   }).property('content'),
 

--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -50,7 +50,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
       numFixedColumns++;
     }
     return numFixedColumns;
-  }).property('numFixedColumns', 'hasGroupingColumn'),
+  }).property('numFixedColumns', '_hasGroupingColumn'),
 
   groupingMetadata: Ember.computed(function() {
     return this.get('content.groupingMetadata') || [];
@@ -289,14 +289,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
     return this.flattenColumnOrColumnGroups(this.get('fixedColumnGroups'));
   }).property('fixedColumnGroups'),
 
-  fixedColumnGroups: Ember.computed(function() {
-    var columns = this.get('_columns');
-    if (!columns) {
-      return Ember.A();
-    }
-    var numFixedColumns = this.get('_numFixedColumns') || 0;
-    return columns.slice(0, numFixedColumns) || [];
-  }).property('_columns.[]', '_numFixedColumns'),
+  fixedColumnGroups: Ember.computed.alias('fixedColumns'),
 
   tableColumns: Ember.computed(function() {
     var columns = this.get('_columns');

--- a/addon/models/lazy-group-row-array.js
+++ b/addon/models/lazy-group-row-array.js
@@ -88,18 +88,26 @@ export default Ember.ArrayProxy.extend({
     return this.get('groupingLevel') < this.get('groupingMetadata.length');
   }).property('groupingMetadata.[]', 'groupingLevel'),
 
+  _group: Ember.computed(function() {
+    if (this.get('isGroupingRow')) {
+      var groupingMetadata = this.get('groupingMetadata');
+      var groupingLevel = this.get('groupingLevel');
+      return groupingMetadata[groupingLevel];
+    }
+    return null;
+  }).property('groupingMetadata.[]', 'groupingLevel'),
+
   triggerLoading: function (index) {
     this.set('_hasInProgressLoading', true);
     var chunkIndex = this.chunkIndex(index);
+    var group = this.get('_group');
     var self = this;
     this.loadOneChunk(chunkIndex).then(function (result) {
       self.onOneChunkLoaded(result);
       self.set('_hasInProgressLoading', false);
-    }).catch(function(response) {
-      self.updatePlaceHolderWithError(response);
-      self.onLoadError("Failed to load data.", response);
+    }).catch(function() {
       self.set('_hasInProgressLoading', false);
-
+      self.onLoadError("Failed to load data.", group, chunkIndex);
     });
   },
 

--- a/addon/views/header-block.js
+++ b/addon/views/header-block.js
@@ -6,6 +6,7 @@ export default TableBlock.extend({
   // TODO(new-api): Eliminate view alias
   itemView: 'header-row',
   itemViewClass: Ember.computed.alias('itemView'),
+  isFixedBlock: false,
 
   content: Ember.computed(function() {
     return [this.get('columns')];

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -17,12 +17,14 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
     }, 0);
   }).property('columns.@each.width'),
   scrollLeft: Ember.computed.alias('tableComponent._tableScrollLeft'),
-
+  isFixedBlock: Ember.computed.alias('parentView.isFixedBlock'),
   rowWidth: Ember.computed(function() {
     var hasColumnGroup = this.get('tableComponent.hasGroupColumn');
     return this.get(hasColumnGroup ? 'width' : 'controller._tableColumnsWidth');
   }),
-
+  isNotFixedBlock: Ember.computed.not('isFixedBlock'),
+  isNotTopRow: Ember.computed.not('isTopRow'),
+  enableColumnReorder: Ember.computed.and('tableComponent.enableColumnReorder', 'isNotTopRow', 'isNotFixedBlock'),
   // Options for jQuery UI sortable
   sortableOption: Ember.computed(function() {
     return {
@@ -57,13 +59,13 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
 
   didInsertElement: function() {
     this._super();
-    if (this.get('tableComponent.enableColumnReorder') && !this.get('isTopRow')) {
+    if (this.get('enableColumnReorder')) {
       this.$('> div').sortable(this.get('sortableOption'));
     }
   },
 
   willDestroyElement: function() {
-    if (this.get('tableComponent.enableColumnReorder') && !this.get('isTopRow')) {
+    if (this.get('enableColumnReorder')) {
       // TODO(azirbel): Get rid of this check, as in onColumnSortDone?
       var $divs = this.$('> div');
       if ($divs) {

--- a/app/templates/header-table-container.hbs
+++ b/app/templates/header-table-container.hbs
@@ -10,6 +10,7 @@
       columns=fixedColumns
       width=_fixedBlockWidth
       height=headerHeight
+      isFixedBlock=true
       }}
     {{/if}}
   {{/if}}


### PR DESCRIPTION
  - In Ember, action is a way better than callback, and we don't need to mark
    error row.
  - Ember-table will register a callback function on LazyGroupRowArray,
    the callback will send `handleDataLoadingError` action,
    with three parameters: errorMessage, groupingLevel, chunkIndex