### PR TITLE
make group row indicator width customizable.

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -117,7 +117,13 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   // By default the indicator view should be supported by ember-table.
   // if you want to custom grouped row view should set a custom view which inherit
   // from 'grouped-row-indicator'.
+  // This view is expected to be positioned as absolute.
   groupedRowIndicatorView: null,
+
+  //Width of group indicator, grouping column will auto expand with each level expanded and
+  //cell content will positioned to the right of group indicator.
+  //If width of custom group row indicator view is not 10 pixel, this property must be set with the real value.
+  groupIndicatorWidth: 10,
 
   // By default the indicator view should be supported by ember-table.
   // if you want to custom grouped row view should set a custom view which inherit

--- a/addon/views/grouped-row-indicator.js
+++ b/addon/views/grouped-row-indicator.js
@@ -20,9 +20,11 @@ export default Ember.View.extend(StyleBindingsMixin, {
 
   expandLevel: 0,
 
+  groupIndicatorWidth: Ember.computed.alias('parentView.groupIndicatorWidth'),
+
   left: Ember.computed(function() {
-    return this.get('expandLevel') * 10 + 5;
-  }).property('expandLevel'),
+    return this.get('parentView.padding-left') - this.get('groupIndicatorWidth');
+  }).property('parentView.padding-left', 'groupIndicatorWidth'),
 
   indicatorClass: Ember.computed(function() {
     var classNames = ['grouping-column-indicator'];

--- a/addon/views/grouping-column-cell.js
+++ b/addon/views/grouping-column-cell.js
@@ -42,8 +42,11 @@ export default TableCell.extend(
     }
   },
 
+  groupIndicatorWidth: Ember.computed.alias('tableComponent.groupIndicatorWidth'),
   "padding-left": Ember.computed(function() {
-    return this.get('expandLevel') * 10 + 15;
+    var groupIndicatorWidth = this.get('groupIndicatorWidth');
+    var numOfGroupIndicators = this.get('expandLevel') + 1; //expandLevel is zero based
+    return numOfGroupIndicators * groupIndicatorWidth + 5;
   }).property('expandLevel'),
 
   isExpanded: Ember.computed.alias('row.isExpanded')


### PR DESCRIPTION
  - cell content will intersect with group row indicator view,
    if width of group row indicator view is larger than 10 pixels.
  - add new property for group row indicator view on ember-table,
    use the new property to calculate padding-left of ember-table
  - users of ember-table must provide width of custom group row indicator
    if its width is not 10 pixel.