### PR TITLE
use padding-right instead of right and set indicator background color

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -438,6 +438,7 @@
       right: 0px;
       bottom: 2px;
       position: absolute;
+      background-color: @table-header-cell-background-color;
 
       .order {
         line-height: 2.4;
@@ -457,8 +458,7 @@
 
   &.sorted {
     .ember-table-content-container .ember-table-content {
-      right: 25px;
-      padding-left: 25px;
+      padding-right: 25px;
     }
   }
 }


### PR DESCRIPTION
Fix defect of sorting first column effected on second column, this is beacuse cell content overflow the bound of header-cell.