### PR TITLE
Fix defect of reordering column group when scroll left.

### DIFF
--- a/addon/mixins/sortable.js
+++ b/addon/mixins/sortable.js
@@ -31,7 +31,6 @@ export default Ember.Mixin.create({
   onColumnSortStart: function(event, ui) {
     // show the dragging element
     ui.item.show();
-
     this.columnSortDidStart();
   },
 
@@ -52,6 +51,9 @@ export default Ember.Mixin.create({
   sortableElement: null,
 
   sortItemName: 'column',
+
+  columnSortDidEnd: Ember.K,
+
   onColumnSortDone: function (event, ui) {
     var newIndex = ui.item.index();
     var sortableElement = this.get('sortableElement');
@@ -60,5 +62,6 @@ export default Ember.Mixin.create({
     var column = view.get(this.get('sortItemName'));
     this.get('tableComponent').onColumnSort(column, newIndex);
     this.set('tableComponent._isShowingSortableIndicator', false);
+    this.columnSortDidEnd();
   }
 });

--- a/addon/views/header-block.js
+++ b/addon/views/header-block.js
@@ -10,5 +10,12 @@ export default TableBlock.extend({
 
   content: Ember.computed(function() {
     return [this.get('columns')];
-  }).property('columns')
+  }).property('columns'),
+
+  onColumnsDidChange: Ember.observer(function() {
+    var _this = this;
+    Ember.run.schedule('afterRender', function() {
+      _this.$().scrollLeft(_this.get('scrollLeft'));
+    });
+  }, 'content')
 });

--- a/addon/views/header-groups-block.js
+++ b/addon/views/header-groups-block.js
@@ -54,6 +54,14 @@ export default Ember.CollectionView.extend(
 
     columnSortDidStart: function() {
       this.set('tableComponent._isReorderInnerColumns', false);
+      this.onScrollLeftDidChange();
+    },
+
+    columnSortDidEnd: function() {
+      var self = this;
+      Ember.run.schedule('afterRender', function() {
+        self.onScrollLeftDidChange();
+      });
     },
 
     didInsertElement: function () {

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -37,10 +37,6 @@ StyleBindingsMixin, RegisterTableComponentMixin, SortableMixin, {
     }
   },
 
-  onScrollLeftDidChange: Ember.observer(function() {
-    this.$().scrollLeft(this.get('scrollLeft'));
-  }, 'scrollLeft'),
-
   didInsertElement: function() {
     this._super();
     if (this.get('enableColumnReorder')) {
@@ -57,10 +53,5 @@ StyleBindingsMixin, RegisterTableComponentMixin, SortableMixin, {
       }
     }
     this._super();
-  },
-
-  onScroll: function(event) {
-    this.set('scrollLeft', event.target.scrollLeft);
-    event.preventDefault();
   }
 });


### PR DESCRIPTION
In  a table which has grouped rows and column groups,
the width of the table is beyond bounds of the parent element width.

When scroll left and reorder column groups.

Then the columns of table are not aligned.

The PR is used to fix the case
