### PR TITLE
use classNameBinding to repalce classNames in Ember.view

### DIFF
--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -437,17 +437,6 @@
       overflow: hidden;
     }
 
-    .column-sort-indicator {
-      width: 25px;
-      right: 0px;
-      bottom: 2px;
-      position: absolute;
-      background-color: @table-header-cell-background-color;
-
-      .order {
-        line-height: 2.4;
-      }
-    }
   }
 
   .ember-table-toggle {
@@ -461,8 +450,30 @@
   }
 
   &.sorted {
-    .ember-table-content-container .ember-table-content {
-      padding-right: 25px;
+    padding: 0;
+    position: relative;
+    // Override the jQuery sortable
+    display: block !important;
+    font-size: 12px !important;
+
+    .ember-table-content-container {
+      display: flex;
+      align-items: flex-start;
+      height: 100%;
+
+      .ember-table-content {
+        flex: 1;
+        font-weight: bold;
+        overflow: hidden;
+        align-self: center;
+        position: static;
+      }
+
+      .column-sort-indicator {
+        padding-left: 5px;
+        display: inline;
+        align-self: center;
+      }
     }
   }
 }

--- a/addon/views/column-sort-indicator.js
+++ b/addon/views/column-sort-indicator.js
@@ -4,8 +4,6 @@ import RegisterTableComponentMixin from 'ember-table/mixins/register-table-compo
 export default Ember.View.extend(RegisterTableComponentMixin,{
   templateName: 'column-sort-indicator',
 
-  classNames: [ 'column-sort-indicator'],
-
   classNameBindings: ['columnCellStyle'],
 
   tagName: 'span',
@@ -22,7 +20,7 @@ export default Ember.View.extend(RegisterTableComponentMixin,{
   }).property('tableComponent.sortingColumns._columns'),
 
   columnCellStyle: Ember.computed(function(){
-    var columnClasses = [];
+    var columnClasses = ['column-sort-indicator'];
     columnClasses = columnClasses.concat(this.get('column.sortIndicatorStyles'));
     return columnClasses.join(' ');
   }).property('column.sortIndicatorStyles')

--- a/app/templates/header-row.hbs
+++ b/app/templates/header-row.hbs
@@ -1,5 +1,5 @@
 {{view "multi-item-collection"
   content=view.content
   itemViewClassField="headerCellViewClass"
-  width="rowWidth"
+  width=rowWidth
 }}


### PR DESCRIPTION
Not modify ember-table-header-cell style and overwrite it on demo-app.