### PR TITLE
Bind data classes in grouping column cell.

### DIFF
--- a/addon/views/grouping-column-cell.js
+++ b/addon/views/grouping-column-cell.js
@@ -9,6 +9,8 @@ export default TableCell.extend(
 
   classNames: ['grouping-column-cell'],
 
+  classNameBindings: 'dataClasses',
+
   styleBindings: ['padding-left'],
 
   groupedRowIndicatorView: Ember.computed(function(){
@@ -55,5 +57,19 @@ export default TableCell.extend(
     return numOfGroupIndicators * groupIndicatorWidth + 5;
   }).property('expandLevel', 'groupIndicatorWidth'),
 
-  isExpanded: Ember.computed.alias('row.isExpanded')
+  isExpanded: Ember.computed.alias('row.isExpanded'),
+
+  dataClasses: Ember.computed('tableComponent.groupingMetadata.[]', 'groupingLevel', function() {
+    let groupingMetadata = this.get('tableComponent.groupingMetadata');
+    let groupingLevel = this.get('groupingLevel');
+
+    if (groupingMetadata && groupingLevel >= 0 && groupingLevel < groupingMetadata.length) {
+      var grouper = groupingMetadata[groupingLevel] || {};
+      let dataClasses = Ember.get(grouper, 'dataClasses');
+      if (dataClasses) {
+        return dataClasses.join(' ');
+      }
+    }
+    return '';
+  })
 });

--- a/tests/unit/components/ember-table-grouping-column-cell-test.js
+++ b/tests/unit/components/ember-table-grouping-column-cell-test.js
@@ -14,7 +14,13 @@ moduleForEmberTable('grouping column cell', function () {
         }
       ],
     groupMeta: {
-      groupingMetadata: [{id: 'accountSection'}, {id:''}]
+      groupingMetadata: [
+        {
+          id: 'accountSection',
+          dataClasses: ['string']
+        },
+        {id:''}
+      ]
     }
   });
 });
@@ -28,4 +34,14 @@ test('render very long string', function (assert) {
   var groupingIndicator = cell.children().eq(1);
   var cellContent = cell.children().eq(2);
   assert.ok(groupingIndicator.offset().left < cellContent.offset().left, 'should render text and indicator in same row');
+});
+
+test('populate data classes', function (assert) {
+  var component = this.subject();
+  var helper = EmberTableHelper.create({_assert: assert, _component: component});
+  this.render();
+
+  var cell = helper.fixedBodyCell(0, 0);
+  assert.ok(cell.hasClass('string'), 'should populate data classes');
+
 });


### PR DESCRIPTION
Currently we can only customize grouping indicator of grouping column cells, there is no way to customize the style of the cell itself. With this PR, if data classes array provided in group meta info, the data classes will be appended in property `class` of the cells.