### PR TITLE
Fix getter/setter deprecation warnings

### DIFF
--- a/addon/controllers/row.js
+++ b/addon/controllers/row.js
@@ -1,14 +1,18 @@
 import Ember from 'ember';
+import computed from "ember-new-computed";
 
 export default Ember.ObjectProxy.extend({
   content: null,
   isShowing: true,
   isHovered: false,
-  isSelected: Ember.computed(function(key, val) {
-    if (arguments.length > 1) {
-      this.get('parentController').setSelected(this, val);
+  isSelected: computed('parentController.selection.[]', {
+    get: function() {
+      return this.get('parentController').isSelected(this);
+    },
+    set: function(key, value) {
+      this.get('parentController').setSelected(this, value);
+      return value;
     }
-    return this.get('parentController').isSelected(this);
-  }).property('parentController.selection.[]')
+  })
 
 });

--- a/addon/models/column-definition.js
+++ b/addon/models/column-definition.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import computed from "ember-new-computed";
 
 export default Ember.Object.extend({
   // ---------------------------------------------------------------------------
@@ -25,9 +26,14 @@ export default Ember.Object.extend({
   sortIndicatorWidth: 0,
 
   // Minimum column width. Affects both manual resizing and automatic resizing.
-  minWidth: Ember.computed(function (_, width) {
-    return (width || 25) + this.get('sortIndicatorWidth'); // if there is not sort indicator, the default minWidth is 25 px
-  }).property('sortIndicatorWidth'),
+  minWidth: computed('sortIndicatorWidth', {
+    get: function() {
+      return 25 + this.get('sortIndicatorWidth'); // if there is not sort indicator, the default minWidth is 25 px
+    },
+    set: function(key, value) {
+      return value + this.get('sortIndicatorWidth');
+    }
+  }),
 
   // Maximum column width. Affects both manual resizing and automatic resizing.
   maxWidth: undefined,

--- a/addon/views/table-cell.js
+++ b/addon/views/table-cell.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import StyleBindingsMixin from 'ember-table/mixins/style-bindings';
 import RegisterTableComponentMixin from 'ember-table/mixins/register-table-component';
+import computed from "ember-new-computed";
 
 export default Ember.View.extend(
 StyleBindingsMixin, RegisterTableComponentMixin, {
@@ -67,17 +68,23 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
     }
   }, 'column.contentPath'),
 
-  cellContent: Ember.computed(function(key, value) {
-    var row = this.get('row');
-    var column = this.get('column');
-    if (!row || !column) {
-      return;
-    }
-    if (arguments.length === 1) {
-      value = column.getCellContent(row);
-    } else {
+  cellContent: computed('row.isLoaded', 'column', {
+    get: function() {
+      var row = this.get('row');
+      var column = this.get('column');
+      if (!row || !column) {
+        return;
+      }
+      return column.getCellContent(row);
+    },
+    set: function(key, value) {
+      var row = this.get('row');
+      var column = this.get('column');
+      if (!row || !column) {
+        return;
+      }
       column.setCellContent(row, value);
+      return value;
     }
-    return value;
-  }).property('row.isLoaded', 'column')
+  })
 });

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-less": "~1.3.1"
+    "ember-cli-less": "~1.3.1",
+    "ember-new-computed": "^1.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Fixes a lot of annoying getter/setter deprecation warnings.

This uses the ember-new-computed addon to fix the getter/setter deprecation warnings in a manner that does not break Ember versions less than 1.11