### PR TITLE
Clean up and fix defect

### DIFF
--- a/addon/controllers/group-row.js
+++ b/addon/controllers/group-row.js
@@ -215,7 +215,7 @@ var GroupRow = Row.extend({
       return parentPath.createChild(this);
     }).property('parentRow.path', 'grouping.key', 'content'),
 
-    expandToLevelDidChange: Ember.observer('target.groupMeta.arbitraryExpandLevel', function () {
+    expandToLevelActionTriggered: Ember.observer('target.groupMeta.expandToLevelAction', function () {
       this.tryExpandChildren();
     }),
 
@@ -226,7 +226,7 @@ var GroupRow = Row.extend({
 
     tryExpandChildren: function() {
       let selfLevel = this.get('expandLevel') + 1; //convert to 1-based
-      let targetLevel = this.get('target.groupMeta.arbitraryExpandLevel');
+      let targetLevel = this.get('target.groupMeta.expandToLevelAction.level');
       if (selfLevel < targetLevel) {
         if (this.get('isLoaded') && !this.get('isExpanded')) {
           this.expandChildren();
@@ -240,6 +240,5 @@ var GroupRow = Row.extend({
     }
   }
 );
-
 
 export default GroupRow;

--- a/addon/controllers/group-row.js
+++ b/addon/controllers/group-row.js
@@ -50,9 +50,6 @@ var GroupRow = Row.extend({
       }
     },
 
-    arbitraryExpandLevelDidChange: Ember.observer('target.groupMeta.arbitraryExpandLevel', function(){
-    }),
-
     subRowsCountDidChange: Ember.observer('subRowsCount', function () {
       var parentRow = this.get('parentRow');
       if (parentRow) {

--- a/tests/fixture/ember-table.js
+++ b/tests/fixture/ember-table.js
@@ -49,7 +49,7 @@ export default Ember.Component.extend(TableSelector, {
   },
   expandToLevel: function(level) {
     Ember.run(() => {
-      this.set('groupMeta.arbitraryExpandLevel', level);
+      this.set('groupMeta.expandToLevelAction', {level: level});
     });
   }
 });

--- a/tests/unit/components/expand-to-arbitrary-level-test.js
+++ b/tests/unit/components/expand-to-arbitrary-level-test.js
@@ -209,3 +209,25 @@ test('expand to level 3 and collapse to level 2 and collapse level 1', function 
     ], "should collapse to level 1.");
   });
 });
+
+test('expand to level 1, expand first grouper then expand to level 1 again', function(assert){
+  var defers = DefersPromise.create({count: 2});
+  var component = this.subject({defers: defers, height: 1000});
+  this.render();
+  var table = TableDom.create({content: component.$()});
+  defers.ready(() => {
+    component.expandToLevel(1);
+    table.row(0).groupIndicator().click();
+  }, [0]);
+
+  defers.ready(() => {
+    component.expandToLevel(1);
+  }, [1]);
+
+  return defers.ready(() => {
+    assert.deepEqual(table.cellsContent(2, [0]), [
+      ["as-1"],
+      ["as-2"]
+    ], "should collapse to level 1.");
+  });
+});


### PR DESCRIPTION
- Remove unused observer in group row
- Fixed defect of not collapse when trigger expand to level 1 twice.