### PR TITLE
make `_previousGrouperSortDirection` be a property of group-row

### DIFF
--- a/addon/controllers/group-row.js
+++ b/addon/controllers/group-row.js
@@ -63,6 +63,8 @@ var GroupRow = Row.extend({
       }
     }),
 
+    _previousGrouperSortDirection: null,
+
     sortingGroupersDidChange: Ember.observer('nextLevelGrouping.sortDirection', function () {
       if (this.get('_childrenRow')) {
         var previousSortDirection = this.get('_previousGrouperSortDirection');
@@ -167,7 +169,8 @@ var GroupRow = Row.extend({
             itemController: this.get('itemController'),
             parentRow: this
           });
-          subRows.setControllerAt(newRow, i);
+          //It can be an old controller.
+          newRow = subRows.setControllerAt(newRow, i);
           newRow.tryExpandChildren();
           return newRow;
         }

--- a/addon/controllers/sub-row-array.js
+++ b/addon/controllers/sub-row-array.js
@@ -33,6 +33,7 @@ var SubRowArray = Ember.ArrayController.extend({
       }
     }
     this.incrementProperty('definedControllersCount', 1);
+    return this._subControllers[idx];
   },
 
   refreshControllerAt: function(idx, content) {


### PR DESCRIPTION
 - Without this `_previousGrouperSortDirection` will be written to group-row's content.
 - Declare the property in group-row, ensures the property value was not written to content.