### PR TITLE
Optimize find row.

### DIFF
--- a/addon/controllers/group-row.js
+++ b/addon/controllers/group-row.js
@@ -23,8 +23,8 @@ var GroupRow = Row.extend({
       return childrenCount + childrenExpandedCount;
     }).property('isExpanded', '_childrenRow.definedControllersCount', '_childrenRow.@each.subRowsCount', '_childrenRow.length'),
 
-    subRowIndex: Ember.computed('_childrenRow.@each.subRowsCount', '_childrenRow.definedControllersCount', function () {
-      var subRows = this.get('_childrenRow');
+    subRowIndex: Ember.computed('_childrenRow.definedControllersCount', 'subRowsCount', function () {
+      var subRows = this.get('_childrenRow') || [];
       var offset = 0;
       var result = [];
       subRows.forEach(function (row, idx) {
@@ -159,59 +159,44 @@ var GroupRow = Row.extend({
       if (!subRows || !subRows.get('length')) {
         return undefined;
       }
-
       var subRowIndex = this.get('subRowIndex');
-
-      var binarySearch = function(array, left, right) {
-        if (left >= right) {
-          return array[left];
-        }
-
-        let leftOffset = subRowIndex[left].offset;
-        let rightOffset = subRowIndex[right].offset;
-        if (right - left === 1) {
-          if (idx < rightOffset) {
-            return array[left];
-          } else {
-            return array[right];
-          }
-        }
-
-        let sum = left + right;
-        let mid = sum % 2 ? (sum + 1) / 2 : sum / 2;
-        let midOffset = subRowIndex[mid].offset;
-
-        if (idx >= leftOffset && idx < midOffset) {
-          return binarySearch(array, left, mid);
-        } else if (idx > midOffset && idx <= rightOffset) {
-          return binarySearch(array, mid, right);
-        } else {
-          return array[mid];
-        }
-      };
-
-      var index = binarySearch(subRowIndex, 0, subRowIndex.length - 1);
-
-      //pow2 = [1];
-      //powIndex = 1;
-      //while (pow2[pow2.length - 1] < subRows.length) {
-      //  pow2.push(Math.pow(2, powIndex));
-      //  powIndex ++;
-      //}
-      //
-      //var index = 0;
-      //for(var i = pow2.length - 1; i >= 0; i--) {
-      //  tmp = index + pow2[i];
-      //  if(tmp < subRowIndex.length && idx >= subRowIndex[tmp].offset) {
-      //    index = tmp;
+      //var binarySearch = function(array, left, right) {
+      //  if (left >= right) {
+      //    return array[left];
       //  }
-      //}
-      //while(i < subRowIndex.length && idx >= subRowIndex[i].offset) {
-      //  index = subRowIndex[i];
-      //  i ++;
-      //}
+      //
+      //  let leftOffset = subRowIndex[left].offset;
+      //  let rightOffset = subRowIndex[right].offset;
+      //  if (right - left === 1) {
+      //    if (idx < rightOffset) {
+      //      return array[left];
+      //    } else {
+      //      return array[right];
+      //    }
+      //  }
+      //
+      //  let sum = left + right;
+      //  let mid = sum % 2 ? (sum + 1) / 2 : sum / 2;
+      //  let midOffset = subRowIndex[mid].offset;
+      //
+      //  if (idx >= leftOffset && idx < midOffset) {
+      //    return binarySearch(array, left, mid);
+      //  } else if (idx > midOffset && idx <= rightOffset) {
+      //    return binarySearch(array, mid, right);
+      //  } else {
+      //    return array[mid];
+      //  }
+      //};
+      //
+      //var index = binarySearch(subRowIndex, 0, subRowIndex.length - 1);
 
-      console.log('findRow', idx, index);
+      var index;
+      var i = 0;
+      while(i < subRowIndex.length && idx >= subRowIndex[i].offset) {
+        index = subRowIndex[i];
+        i ++;
+      }
+
       var row = subRows.objectAt(index.rowIndex);
       if (idx === index.offset) {
         return row;

--- a/addon/views/lazy-container.js
+++ b/addon/views/lazy-container.js
@@ -75,6 +75,9 @@ StyleBindingsMixin, {
     }
     // for all views that we are not using... just remove content
     // this makes them invisible
+    if (content && content.get('_virtualRootRow')) {
+      content.get('_virtualRootRow').notifyPropertyChange('subRowIndex');
+    }
     childViews.forEach(function(childView, i) {
       if (i >= numShownViews) {
         childView.set('content', null);
@@ -90,5 +93,5 @@ StyleBindingsMixin, {
         childView.prepareContent();
       }
     });
-  }, 'content.length', 'length', 'startIndex', 'sortingColumns._columns')
+  }, 'content.length', 'length', 'startIndex')
 });

--- a/tests/unit/components/chunked-grouping-row-test.js
+++ b/tests/unit/components/chunked-grouping-row-test.js
@@ -138,6 +138,7 @@ test('show grouping name in grouping column', function (assert) {
     helper.rowGroupingIndicator(0).click();
   }, [0]);
 
+  defers.next();
   return defers.ready(function () {
     var secondRowGroupingName = helper.fixedBodyCell(1, 0).text().trim();
     assert.equal(secondRowGroupingName, "secondLevel-0", 'it should show second level grouping name');

--- a/tests/unit/components/chunked-grouping-row-test.js
+++ b/tests/unit/components/chunked-grouping-row-test.js
@@ -114,7 +114,7 @@ test('load top level chunk data in need', function (assert) {
 });
 
 test('show grouping name in grouping column', function (assert) {
-  var defers = DeferPromises.create({count: 2});
+  var defers = DeferPromises.create();
   var chunkSize = 5;
   var component = this.subject({
       loadChildren: function getChunk() {
@@ -138,7 +138,6 @@ test('show grouping name in grouping column', function (assert) {
     helper.rowGroupingIndicator(0).click();
   }, [0]);
 
-  defers.next();
   return defers.ready(function () {
     var secondRowGroupingName = helper.fixedBodyCell(1, 0).text().trim();
     assert.equal(secondRowGroupingName, "secondLevel-0", 'it should show second level grouping name');

--- a/tests/unit/controllers/group-row-test.js
+++ b/tests/unit/controllers/group-row-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import GroupRow from 'ember-table/controllers/group-row';
 import Grouping from 'ember-table/models/grouping';
 
@@ -28,12 +28,17 @@ test('group name', function (assert) {
   assert.equal(groupRow.get('groupName'), 'groupName');
 });
 
+test('find row 0', function (assert) {
+  assert.ok(groupRow.findRow(1) === undefined);
+});
+
 module('grouping row is expanded', {
   beforeEach: function () {
     groupRow = GroupRow.create({
       expandLevel: 0,
-      content: {id: 1, children: [{id: 11}]},
-      grouping: {isGroup: true}
+      content: {id: 1, children: [{id: 11}, {id: 12}]},
+      grouping: {isGroup: true},
+      itemController: GroupRow
     });
     groupRow.expandChildren();
   },
@@ -45,7 +50,45 @@ module('grouping row is expanded', {
 test('subRowsCount', function (assert) {
   var subRowsCount = groupRow.get('subRowsCount');
 
-  assert.equal(subRowsCount, 1);
+  assert.equal(subRowsCount, 2);
+});
+
+test('subRowIndex', function (assert) {
+  groupRow.createRow(0);
+  groupRow.createRow(1);
+  var subRowIndex = groupRow.get('subRowIndex');
+
+  assert.deepEqual(subRowIndex, [
+    {
+      offset: 0,
+      rowIndex: 0,
+    }, {
+      offset: 1,
+      rowIndex: 1
+    }
+  ]);
+});
+
+test('subRowIndex inCompleted', function (assert) {
+  groupRow.createRow(0);
+  var subRowIndex = groupRow.get('subRowIndex');
+  assert.deepEqual(subRowIndex, [
+    {
+      offset: 0,
+      rowIndex: 0
+    }, {
+      offset: 1,
+      rowIndex: 1
+    }
+  ]);
+});
+
+test('find row 0', function (assert) {
+  assert.ok(groupRow.findRow(0) === undefined, 'no group row defined by default');
+
+  var createdRow = groupRow.createRow(0);
+
+  assert.equal(groupRow.findRow(0), createdRow, 'should find created row');
 });
 
 module('grouping row is collapsed', {
@@ -66,6 +109,10 @@ test('subRowsCount', function (assert) {
   var subRowsCount = groupRow.get('subRowsCount');
 
   assert.equal(subRowsCount, 0);
+});
+
+test('find row 0', function (assert) {
+  assert.ok(groupRow.findRow(0) === undefined);
 });
 
 module('grouping row is expanded but has no children row', {
@@ -117,4 +164,69 @@ test('children of leaf node', function (assert) {
   let children = groupRow.get('children');
 
   assert.ok(children === undefined, 'should not use lazy load children for leaf node');
+});
+
+module('group row with nested children', {
+  beforeEach() {
+    groupRow = GroupRow.create({
+      itemController: GroupRow,
+      grouping: {isGroup: true},
+      nextLevelGrouping: {isGroup: true},
+      content: {
+        id: 1,
+        children: [
+          {
+            id: 11,
+            children: [
+              {id: 111}, {id: 112}
+            ]
+          },
+          {
+            id: 12,
+            children: [
+              {id: 121}, {id: 122}
+            ]
+          }
+        ]
+      }
+    });
+    groupRow.expandChildren();
+    groupRow.createRow(0);
+    groupRow.createRow(1);
+  }
+});
+
+test('find children of 11', function (assert) {
+  let row11 = groupRow.findRow(0);
+  row11.expandChildren();
+
+  assert.ok(groupRow.findRow(1) === undefined, 'no children row by default');
+
+  var row111 = groupRow.createRow(1);
+  assert.equal(row111.get('id'), 111, 'should return created row 111');
+  assert.equal(Ember.guidFor(groupRow.findRow(1)), Ember.guidFor(row111), 'should find created row 111');
+});
+
+test('find children of 12 when 11 is collapsed', function (assert) {
+  let row12 = groupRow.findRow(1);
+  row12.expandChildren();
+
+  assert.ok(groupRow.findRow(2) === undefined, 'no children row by default');
+
+  var row121 = groupRow.createRow(2);
+  assert.equal(row121.get('id'), 121, 'should return created row 121');
+  assert.equal(Ember.guidFor(groupRow.findRow(2)), Ember.guidFor(row121), 'should find created row 121');
+});
+
+test('find children of 12 when 11 is expanded', function (assert) {
+  let row11 = groupRow.findRow(0);
+  row11.expandChildren();
+  let row12 = groupRow.findRow(3);
+  row12.expandChildren();
+
+  assert.ok(groupRow.findRow(4) === undefined, 'no children row by default');
+
+  var row121 = groupRow.createRow(4);
+  assert.equal(row121.get('id'), 121, 'should return created row 121');
+  assert.equal(Ember.guidFor(groupRow.findRow(4)), Ember.guidFor(row121), 'should find created row 121');
 });

--- a/tests/unit/controllers/group-row-test.js
+++ b/tests/unit/controllers/group-row-test.js
@@ -168,17 +168,21 @@ test('children of leaf node', function (assert) {
 
 module('group row with nested children', {
   beforeEach() {
+    let grouping = {isGroup: true};
+    grouping.nextLevelGrouping = grouping;
     groupRow = GroupRow.create({
       itemController: GroupRow,
-      grouping: {isGroup: true},
-      nextLevelGrouping: {isGroup: true},
+      grouping: grouping,
       content: {
         id: 1,
         children: [
           {
             id: 11,
             children: [
-              {id: 111}, {id: 112}
+              {
+                id: 111,
+                children: [{id: 1111}]
+              }, {id: 112}
             ]
           },
           {
@@ -229,4 +233,18 @@ test('find children of 12 when 11 is expanded', function (assert) {
   var row121 = groupRow.createRow(4);
   assert.equal(row121.get('id'), 121, 'should return created row 121');
   assert.equal(Ember.guidFor(groupRow.findRow(4)), Ember.guidFor(row121), 'should find created row 121');
+});
+
+test('find children of 111', function (assert) {
+  let row11 = groupRow.findRow(0);
+  row11.expandChildren();
+  groupRow.createRow(1);
+  let row111 = groupRow.findRow(1);
+  row111.expandChildren();
+
+  assert.ok(groupRow.findRow(2) === undefined, 'no children row by default');
+
+  var row1111 = groupRow.createRow(2);
+  assert.equal(row1111.get('id'), 1111, 'should return created row 1111');
+  assert.equal(Ember.guidFor(groupRow.findRow(2)), Ember.guidFor(row1111), 'should find created row 1111');
 });


### PR DESCRIPTION
- Use binary search to find row. 
- When there are more than 1500 rows under one node, and scroll to show rows >1000, the refresh time can be 1to 2 seconds.