### PR TITLE
Add ability to customize footer with its own view class

### DIFF
--- a/addon/models/column-definition.js
+++ b/addon/models/column-definition.js
@@ -67,6 +67,11 @@ export default Ember.Object.extend({
   tableCellView: 'table-cell',
   tableCellViewClass: Ember.computed.alias('tableCellView'),
 
+  // TODO(new-api): Remove `footerCellViewClass`
+  // Override to specify a custom view to use for the footer cells.
+  footerCellView: Ember.computed.oneWay('tableCellView'), // default to tableCellView if not provided
+  footerCellViewClass: Ember.computed.alias('footerCellView'),
+
   // Override to customize how the column gets data from each row object.
   // Given a row, should return a formatted cell value, e.g. $20,000,000.
   getCellContent: function(row) {

--- a/addon/views/footer-block.js
+++ b/addon/views/footer-block.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import TableBlock from './table-block';
+
+export default TableBlock.extend({
+  classNames: ['ember-table-footer-block'],
+  // TODO(new-api): Eliminate view alias
+  itemView: 'footer-row',
+  itemViewClass: Ember.computed.alias('itemView'),
+  isFixedBlock: false
+});

--- a/addon/views/footer-row.js
+++ b/addon/views/footer-row.js
@@ -1,0 +1,8 @@
+import TableRow from "../views/table-row";
+import RegisterTableComponentMixin from 'ember-table/mixins/register-table-component';
+
+export default TableRow.extend(
+RegisterTableComponentMixin, {
+  templateName: 'footer-row',
+  classNames: 'ember-table-footer-row'
+});

--- a/app/templates/footer-row.hbs
+++ b/app/templates/footer-row.hbs
@@ -1,0 +1,5 @@
+{{view "multi-item-collection"
+  row=view.row
+  content=view.columns
+  itemViewClassField="footerCellViewClass"
+}}

--- a/app/templates/footer-table-container.hbs
+++ b/app/templates/footer-table-container.hbs
@@ -1,13 +1,13 @@
 <div class="ember-table-table-fixed-wrapper">
   {{#if numFixedColumns}}
-    {{view "table-block" classNames="ember-table-left-table-block"
+    {{view "footer-block" classNames="ember-table-left-table-block"
       content=footerContent
       columns=fixedColumns
       width=_fixedBlockWidth
       height=footerHeight
     }}
   {{/if}}
-  {{view "table-block" classNames="ember-table-right-table-block"
+  {{view "footer-block" classNames="ember-table-right-table-block"
     content=footerContent
     columns=tableColumns
     scrollLeft=_tableScrollLeft

--- a/app/views/footer-block.js
+++ b/app/views/footer-block.js
@@ -1,0 +1,3 @@
+import FooterBlock from 'ember-table/views/footer-block';
+
+export default FooterBlock;

--- a/app/views/footer-row.js
+++ b/app/views/footer-row.js
@@ -1,0 +1,3 @@
+import FooterRow from 'ember-table/views/footer-row';
+
+export default FooterRow;


### PR DESCRIPTION
This enables the user of ember-table to provide a footerCellView similar to headerCellView and tableCellView to be able to customize the look of the footer.