### PR TITLE
Enable customizing grouping column header

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -112,6 +112,10 @@ StyleBindingsMixin, ResizeHandlerMixin, {
 
   groupingColumnWidth: 150,
 
+  groupingHeaderCellName: '',
+
+  groupingHeaderCellViewName: 'header-cell',
+
   // By default the indicator view should be supported by ember-table.
   // if you want to custom grouped row view should set a custom view which inherit
   // from 'grouped-row-indicator'.
@@ -425,13 +429,14 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   _groupingColumn: Ember.computed(function () {
     var groupingColumnWidth = this.get('groupingColumnWidth');
     return ColumnDefinition.create({
-      headerCellName: '', //Todo: Fix grouping header name
+      headerCellName: this.get('groupingHeaderCellName'),
       textAlign: 'text-align-left',
       isSortable: false,
       sortFn: null,
       minWidth: 40, // Prevent cell content from changing into '...' then into normal string.
       savedWidth: groupingColumnWidth,
       tableCellView: 'grouping-column-cell',
+      headerCellView: this.get('groupingHeaderCellViewName'),
       getCellContent: function (row) {
         return row.get('groupName');
       }


### PR DESCRIPTION
This allows you to specify what is shown in the header of the grouping column.

Example:

![screen shot 2016-02-10 at 12 54 11 pm](https://cloud.githubusercontent.com/assets/313960/12956312/6e3a21ac-cff5-11e5-80a3-5cbe64731f3a.png)
